### PR TITLE
Update Dockerfile - copy neccessary files to /test/ workdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM mcr.microsoft.com/playwright:v1.48.0-jammy
 WORKDIR /test
+
+# Copy the package.json and package-lock.json
+COPY package.json /test/
+COPY package-lock.json /test/
+COPY playwright.config.ts /test/
+
 RUN npx -y playwright@1.48.0 install --with-deps && \
     npm install dotenv --production
 CMD ["npx", "playwright", "test"]


### PR DESCRIPTION
**Ensure the correct working directory:** The error also shows that the playwright.config.ts file is in /test/, which is the directory specified by WORKDIR. Make sure your Playwright configuration is in the right path when the Docker image runs.