### PR TITLE
Upgrade playwright version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM mcr.microsoft.com/playwright:v1.48.0-jammy
+FROM mcr.microsoft.com/playwright:v1.56.1-jammy
 WORKDIR /test
-RUN npx -y playwright@1.48.0 install --with-deps && \
+RUN npx -y playwright@1.56.1 install --with-deps && \
     npm install dotenv --production
 CMD ["npx", "playwright", "test"]


### PR DESCRIPTION
Upgrade Playwright from 1.48.0 to 1.56.1 to align with the actual version being used and fix version mismatch issues.

<img width="484" height="155" alt="image" src="https://github.com/user-attachments/assets/2078711a-43bf-4e93-ba16-41c4d76f001a" />
