### PR TITLE
Bump actions/* to latest major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           MS_TEAMS_URI: ${{ secrets.MS_DQ_TEAMS_WEBHOOK_URI }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: pull and build
         run: |


### PR DESCRIPTION
Update GitHub Actions to their current latest major releases:

- `actions/cache@v5`
- `actions/checkout@v6`
- `actions/download-artifact@v8`
- `actions/github-script@v9`
- `actions/setup-python@v6`
- `actions/stale@v10`
- `actions/upload-artifact@v7`

Only versions actually present in this repository's workflows are touched.

Note: newer majors of these actions ship with Node.js 24 runtime. Workflows that run inside legacy containers (Ubuntu 20 / older glibc) may need their container image bumped — watch CI.